### PR TITLE
remove push jobs from pull request workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -6,38 +6,6 @@ on:
       - opened
 
 jobs:
-  quality-control:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: php-actions/composer@v6
-        with:
-          php_version: 8.1
-
-      - name: PHPStan
-        uses: php-actions/phpstan@v3
-        with:
-          path: public/
-          php_version: 8.1
-
-      - name: PHP Code Sniffer
-        uses: php-actions/phpcs@v1
-        with:
-          path: public/
-          standard: PSR12
-          warning_severity: 0
-          php_version: 8.1
-
-      - name: PHP Mess Detector
-        uses: php-actions/phpmd@v1
-        with:
-          php_version: 8.1
-          path: public/
-          output: text
-          ruleset: cleancode,codesize,controversial,design,naming,unusedcode
-
-
   pull-request-review:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
PR workflow still contained jobs that already run on push

Does this close any currently open issues?
------------------------------------------



Any other comments?
-------------------

